### PR TITLE
Fix `save_file` method

### DIFF
--- a/lib/hpctmanagers/__init__.py
+++ b/lib/hpctmanagers/__init__.py
@@ -15,7 +15,6 @@ import pathlib
 import pwd
 import subprocess
 
-
 _null_logger = logging.getLogger(__name__)
 _null_logger.addHandler(logging.NullHandler())
 
@@ -137,7 +136,7 @@ class Manager:
             if mode != None:
                 p.chmod(mode)
 
-            p.write_bytes(self.data)
+            p.write_bytes(data)
         except:
             raise Exception("failed to save file")
 


### PR DESCRIPTION
This pull request fixes and closes issue #7 by changing `self.data` to `data` in the `save_file` method provided by the Manager super-class.